### PR TITLE
Fix calculator modal style block

### DIFF
--- a/src/features/pos/presentation/components/CalculatorModel.vue
+++ b/src/features/pos/presentation/components/CalculatorModel.vue
@@ -205,3 +205,16 @@ function handleAssign() {
 <style scoped>
 .calculator-grid {
   display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(5, 1fr);
+  gap: 4px;
+}
+
+.row-span-2 {
+  grid-row: span 2;
+}
+
+.col-span-2 {
+  grid-column: span 2;
+}
+</style>


### PR DESCRIPTION
## Summary
- fill out calculator-grid CSS
- add closing style tag

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855a0b53aac832da7d4a69efd5d2fe8