### PR TITLE
Fix order status property name

### DIFF
--- a/src/features/pos/domain/Entities/Order.ts
+++ b/src/features/pos/domain/Entities/Order.ts
@@ -9,7 +9,7 @@ export interface Order
     readonly subtotal: number;
     readonly taxes: number;
     readonly total: number;
-    readonly timesstatus: OrderStatus;
+    readonly status: OrderStatus;
 }
 
 export type OrderStatus = 'Pendiente' 


### PR DESCRIPTION
## Summary
- update Order entity to rename `timesstatus` to `status`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855ccfbcdf0832db6a8a95d2312cd63