### PR TITLE
Add unit tests for services and stores

### DIFF
--- a/src/features/pos/application/stores/__tests__/useCalculatorStore.test.ts
+++ b/src/features/pos/application/stores/__tests__/useCalculatorStore.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCalculatorStore } from '../useCalculatorStore'
+
+describe('useCalculatorStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('performs basic operations', () => {
+    const store = useCalculatorStore()
+
+    store.inputNumber(5)
+    expect(store.state.display).toBe('5')
+
+    store.performOperation('+')
+    store.inputNumber(3)
+    store.performOperation('=')
+
+    expect(store.state.display).toBe('8')
+  })
+
+  it('controls open state', () => {
+    const store = useCalculatorStore()
+    store.open()
+    expect(store.isOpen).toBe(true)
+    store.close()
+    expect(store.isOpen).toBe(false)
+  })
+})

--- a/src/features/pos/application/stores/__tests__/usePaymentStore.test.ts
+++ b/src/features/pos/application/stores/__tests__/usePaymentStore.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePaymentStore } from '../usePaymentStore'
+import { useOrderStore } from '../useOrderStore'
+
+describe('usePaymentStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('assigns payments and updates totals', () => {
+    const orderStore = useOrderStore()
+    const store = usePaymentStore()
+
+    store.setActiveMethod('Efectivo')
+    store.assignPayment(5)
+
+    expect(store.payments.length).toBe(1)
+    expect(store.totalAssigned).toBe(5)
+    expect(store.remainingAmount).toBeCloseTo(orderStore.total - 5)
+  })
+
+  it('removes payments by method', () => {
+    useOrderStore()
+    const store = usePaymentStore()
+
+    store.setActiveMethod('Efectivo')
+    store.assignPayment(3)
+    store.setActiveMethod('Cartera')
+    store.assignPayment(2)
+
+    expect(store.payments.length).toBe(2)
+
+    store.removePaymentsByMethod('Efectivo')
+    expect(store.payments.every(p => p.method !== 'Efectivo')).toBe(true)
+  })
+})

--- a/src/features/pos/domain/services/__tests__/PaymentService.test.ts
+++ b/src/features/pos/domain/services/__tests__/PaymentService.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { PaymentService } from '../PaymentService'
+import type { Payment } from '../../Entities/Payment'
+
+describe('PaymentService', () => {
+  it('creates a payment rounding amount', () => {
+    const payment = PaymentService.createPayment('Efectivo', 10.555, 'ref')
+
+    expect(payment.method).toBe('Efectivo')
+    expect(payment.amount).toBe(10.56)
+    expect(typeof payment.id).toBe('string')
+    expect(payment.timestamp).toBeInstanceOf(Date)
+    expect(payment.reference).toBe('ref')
+  })
+
+  it('validates payment rules', () => {
+    const base: Payment = {
+      id: '1',
+      method: 'Transferencia',
+      amount: -5,
+      timestamp: new Date()
+    }
+    const errors1 = PaymentService.validatePayment(base)
+    expect(errors1).toContain('El monto debe ser mayor a 0')
+
+    const high: Payment = { ...base, amount: 1000000 }
+    const errors2 = PaymentService.validatePayment(high)
+    expect(errors2).toContain('El monto excede el límite máximo')
+
+    const missingRef: Payment = { ...base, amount: 10 }
+    const errors3 = PaymentService.validatePayment(missingRef)
+    expect(errors3).toContain('Transferencia requiere referencia')
+  })
+
+  it('groups payments by method', () => {
+    const p1 = PaymentService.createPayment('Efectivo', 5)
+    const p2 = PaymentService.createPayment('Cartera', 2)
+    const p3 = PaymentService.createPayment('Efectivo', 3)
+
+    const grouped = PaymentService.groupByMethod([p1, p2, p3])
+    expect(grouped.get('Efectivo')!.length).toBe(2)
+    expect(grouped.get('Cartera')!.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for PaymentService creation, validation and grouping
- cover payment store core actions
- cover calculator store operations

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6855cf5fede0832daad8e67ea19a35ba