### PR TITLE
Fix router import paths

### DIFF
--- a/src/app/router/routes.ts
+++ b/src/app/router/routes.ts
@@ -3,15 +3,15 @@ import type { RouteRecordRaw } from 'vue-router';
 const routes: RouteRecordRaw[] = [
   {
     path: '/',
-    component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/IndexPage.vue') }],
+    component: () => import('../layouts/MainLayout.vue'),
+    children: [{ path: '', component: () => import('../pages/IndexPage.vue') }],
   },
 
   // Always leave this as last one,
   // but you can also remove it
   {
     path: '/:catchAll(.*)*',
-    component: () => import('pages/ErrorNotFound.vue'),
+    component: () => import('../pages/ErrorNotFound.vue'),
   },
 ];
 


### PR DESCRIPTION
## Summary
- use relative paths in router module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: quasar not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6cca7528832db5637bd78be04583