### PR TITLE
Add Order Items page

### DIFF
--- a/src/app/pages/OrderItemsPage.vue
+++ b/src/app/pages/OrderItemsPage.vue
@@ -1,0 +1,48 @@
+<template>
+  <q-page class="q-pa-md">
+    <q-table
+      flat
+      bordered
+      :rows="items"
+      :columns="columns"
+      row-key="id"
+      hide-bottom
+      :rows-per-page-options="[0]"
+    />
+    <div class="text-right q-mt-md">
+      <div>Subtotal: ${{ subtotal.toFixed(2) }}</div>
+      <div>Impuestos: ${{ taxes.toFixed(2) }}</div>
+      <div class="text-weight-bold">Total: ${{ total.toFixed(2) }}</div>
+    </div>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { useOrderStore } from '../../features/pos/application/stores/useOrderStore'
+
+const orderStore = useOrderStore()
+
+const items = orderStore.items
+const subtotal = orderStore.subtotal
+const taxes = orderStore.taxes
+const total = orderStore.total
+
+const columns = [
+  { name: 'name', label: 'Nombre', field: 'name', align: 'left' },
+  {
+    name: 'price',
+    label: 'Precio',
+    field: 'price',
+    align: 'right',
+    format: (val: number) => val.toFixed(2)
+  },
+  { name: 'quantity', label: 'Cantidad', field: 'quantity', align: 'right' },
+  {
+    name: 'total',
+    label: 'Total',
+    field: 'total',
+    align: 'right',
+    format: (val: number) => val.toFixed(2)
+  }
+]
+</script>

--- a/src/app/router/routes.ts
+++ b/src/app/router/routes.ts
@@ -4,7 +4,12 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/',
     component: () => import('../layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('../pages/IndexPage.vue') }],
+    children: [{ path: '', component: () => import('../pages/OrderItemsPage.vue') }],
+  },
+
+  {
+    path: '/example',
+    component: () => import('../pages/IndexPage.vue'),
   },
 
   // Always leave this as last one,


### PR DESCRIPTION
## Summary
- add `OrderItemsPage.vue` displaying the order items from the Pinia store
- route `/` to the new page
- keep the old example page on `/example`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68659b7571f4832d80ee814a579ece54